### PR TITLE
Add validation to the login input fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "react": "18.2.0",
-        "react-native": "0.74.1"
+        "react-native": "0.74.1",
+        "zod": "^3.23.6"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -14112,6 +14113,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.6.tgz",
+      "integrity": "sha512-RTHJlZhsRbuA8Hmp/iNL7jnfc4nZishjsanDAfEY1QpDQZCahUp3xDzl+zfweE9BklxMUcgBgS1b7Lvie/ZVwA==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "18.2.0",
-    "react-native": "0.74.1"
+    "react-native": "0.74.1",
+    "zod": "^3.23.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/screens/login/Login.tsx
+++ b/src/screens/login/Login.tsx
@@ -3,8 +3,28 @@ import * as React from 'react';
 import {Text, View, TextInput, TouchableOpacity} from 'react-native';
 
 import {styles} from './/styles';
+import {validateLoginData} from './validation';
 
 export const Login = () => {
+  const [email, setEmail] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  const [emailError, setEmailError] = React.useState('');
+  const [passwordError, setPasswordError] = React.useState('');
+
+  const handleFormSubmit = () => {
+    // Reseting errors
+    setEmailError('');
+    setPasswordError('');
+
+    const errors = validateLoginData({email, password});
+    if (errors.email.length > 0) {
+      setEmailError(errors.email[0]);
+    }
+    if (errors.password.length > 0) {
+      setPasswordError(errors.password[0]);
+    }
+  };
+
   return (
     <View style={styles.loginContainer}>
       <Text style={styles.title}>Bem-vindo(a) à Taqtile</Text>
@@ -12,19 +32,28 @@ export const Login = () => {
         <View>
           <Text style={styles.inputLabel}>E-mail</Text>
           <TextInput
+            value={email}
+            onChangeText={setEmail}
             style={styles.input}
             autoCapitalize="none"
             inputMode="email"
             autoCorrect={false}
           />
+          <Text style={styles.errorsText}>{emailError}</Text>
         </View>
         <View>
           <Text style={styles.inputLabel}>Senha</Text>
-          <TextInput style={styles.input} secureTextEntry />
+          <TextInput
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+            style={styles.input}
+          />
+          <Text style={styles.errorsText}>{passwordError}</Text>
         </View>
       </View>
 
-      <TouchableOpacity style={styles.submitButton}>
+      <TouchableOpacity style={styles.submitButton} onPress={handleFormSubmit}>
         <Text style={styles.submitButtoText}>Entrar</Text>
       </TouchableOpacity>
     </View>

--- a/src/screens/login/styles.ts
+++ b/src/screens/login/styles.ts
@@ -4,6 +4,11 @@ export const styles = StyleSheet.create({
   loginContainer: {
     marginTop: 32,
   },
+  errorsText: {
+    color: '#fc4444',
+    fontSize: 10,
+    marginLeft: 8,
+  },
   title: {
     color: '#090909',
     fontSize: 32,

--- a/src/screens/login/validation.ts
+++ b/src/screens/login/validation.ts
@@ -43,7 +43,7 @@ export function validateLoginData(loginData: LoginData): LoginErrors {
       return {
         email: fieldErrors.email || [],
         password: fieldErrors.password || [],
-      }; // Returns an array of errors per field, leaving an empty array is there is no errors
+      };
     }
 
     return noErrorResponse; // Default to the no-error response

--- a/src/screens/login/validation.ts
+++ b/src/screens/login/validation.ts
@@ -1,0 +1,51 @@
+import {z} from 'zod';
+import {ZodError} from 'zod';
+
+interface LoginData {
+  email: string;
+  password: string;
+}
+
+interface LoginErrors {
+  email: Array<string>;
+  password: Array<string>;
+}
+
+const refinePasswordValidation = (password: string) => {
+  if (/\d/.test(password) && /\w/.test(password)) {
+    return true;
+  }
+  return false;
+};
+
+const LoginSchema = z.object({
+  // Translating messages to agree with the interface
+  email: z
+    .string()
+    .min(1, {message: 'Email é obrigatório.'})
+    .email({message: 'E-mail inválido.'}),
+  password: z
+    .string()
+    .min(7, {message: 'Senha deve ter no mínimo 7 caracteres.'})
+    .refine(refinePasswordValidation, {
+      message: 'Senha deve ter um dígito e uma letra.',
+    }),
+});
+
+export function validateLoginData(loginData: LoginData): LoginErrors {
+  const noErrorResponse = {email: [], password: []};
+  try {
+    LoginSchema.parse(loginData);
+    return noErrorResponse;
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const {fieldErrors} = error.formErrors;
+      return {
+        email: fieldErrors.email || [],
+        password: fieldErrors.password || [],
+      }; // Returns an array of errors per field, leaving an empty array is there is no errors
+    }
+
+    return noErrorResponse; // Default to the no-error response
+  }
+}


### PR DESCRIPTION
Adicionando rotinas para validar o que é digitado nos campos de login seguindo as regras abaixo, especificadas na task:

- Email input:
  - Should have a valid email format: ###@###.com
  - Should not be empty (required field)
  - Password input:
- Password input:
  - Should not be empty (required field)
  - Minimum of 7 characters
  - Should have at least one digit and one letter

Para auxiliar no trabalho e deixar a validação mais versátil, foram utilizados os recursos da biblioteca [zod.dev](https://zod.dev/). As mensagens de erro capturadas foram inseridas na interface, como mostra a imagem abaixo:

![Simulator Screenshot - iPhone SE (3rd generation) - 2024-05-06 at 10 47 43](https://github.com/indigotech/onboard-davi-felix/assets/62623519/9001a244-28ec-4984-9de6-52fb3e3322d1)
