### PR TITLE
Add infinite scroll without caching

### DIFF
--- a/src/components/loading-indicator/LoadingIndicator.tsx
+++ b/src/components/loading-indicator/LoadingIndicator.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import {View, ActivityIndicator} from 'react-native';
+
+import {styles} from './styles';
+
+export const LoadingIndicator = () => {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator />
+    </View>
+  );
+};

--- a/src/components/loading-indicator/styles.ts
+++ b/src/components/loading-indicator/styles.ts
@@ -1,0 +1,9 @@
+import {StyleSheet} from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/globalStyles.ts
+++ b/src/globalStyles.ts
@@ -3,6 +3,7 @@ import {StyleSheet} from 'react-native';
 export const globalStyles = StyleSheet.create({
   container: {
     margin: 8,
+    flex: 1,
   },
   title: {
     color: '#090909',

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -16,8 +16,18 @@ interface User {
   email: string;
 }
 
+interface PageInfo {
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  offset: number;
+  limit: number;
+}
+
 interface ListUsersData {
-  users: {nodes: User[]};
+  users: {
+    nodes: User[];
+    pageInfo: PageInfo;
+  };
 }
 
 interface PageData {
@@ -32,6 +42,9 @@ const GET_USERS = gql`
         id
         name
         email
+      }
+      pageInfo {
+        hasNextPage
       }
     }
   }
@@ -71,7 +84,9 @@ export const Home = () => {
   }
 
   function handleEndReached() {
-    setCurrentPage(currentPage + 1);
+    if (data?.users.pageInfo.hasNextPage) {
+      setCurrentPage(currentPage + 1);
+    }
   }
 
   function handleQueryCompleted() {

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -1,13 +1,24 @@
 import * as React from 'react';
 
-import {ActivityIndicator, SafeAreaView, ScrollView, Text} from 'react-native';
+import {SafeAreaView, ScrollView, Text} from 'react-native';
 
 import {globalStyles} from '@src/globalStyles';
 import {styles} from './styles';
 
 import {UserItem} from './components/UserItem';
+import {LoadingIndicator} from '@src/components/loading-indicator/LoadingIndicator';
 
 import {gql, useQuery} from '@apollo/client';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+interface ListUsersData {
+  users: {nodes: User[]};
+}
 
 const GET_USERS = gql`
   query ListUsers {
@@ -22,23 +33,27 @@ const GET_USERS = gql`
 `;
 
 export const Home = () => {
-  const {data, loading, error} = useQuery(GET_USERS);
+  const {data, loading, error} = useQuery<ListUsersData>(GET_USERS);
 
   if (error) {
     console.log(error);
   }
 
   if (loading) {
-    return <ActivityIndicator />;
+    return <LoadingIndicator />;
   }
 
   return (
     <SafeAreaView style={globalStyles.container}>
       <Text style={globalStyles.title}>Lista de usuários</Text>
       <ScrollView style={styles.userListContainer}>
-        {data.users.nodes.map(user => (
-          <UserItem name={user.name} email={user.email} key={user.id} />
-        ))}
+        {data && data.users.nodes.length > 0 ? (
+          data.users.nodes.map(user => (
+            <UserItem name={user.name} email={user.email} key={user.id} />
+          ))
+        ) : (
+          <Text>Sem usuários para listas</Text>
+        )}
       </ScrollView>
     </SafeAreaView>
   );

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {SafeAreaView, ScrollView, Text} from 'react-native';
+import {SafeAreaView, ScrollView, Text, Alert} from 'react-native';
 
 import {globalStyles} from '@src/globalStyles';
 import {styles} from './styles';
@@ -33,10 +33,27 @@ const GET_USERS = gql`
 `;
 
 export const Home = () => {
-  const {data, loading, error} = useQuery<ListUsersData>(GET_USERS);
+  const {data, loading, error, refetch} = useQuery<ListUsersData>(GET_USERS, {
+    notifyOnNetworkStatusChange: true,
+  });
+
+  const showAlert = () =>
+    Alert.alert(
+      'Erro',
+      'Houve um erro na requisição para listagem dos usuários',
+      [
+        {
+          text: 'Tentar novamente',
+          onPress: () => {
+            refetch();
+          },
+          style: 'default',
+        },
+      ],
+    );
 
   if (error) {
-    console.log(error);
+    showAlert();
   }
 
   if (loading) {
@@ -52,7 +69,7 @@ export const Home = () => {
             <UserItem name={user.name} email={user.email} key={user.id} />
           ))
         ) : (
-          <Text>Sem usuários para listas</Text>
+          <Text>Sem usuários para listar</Text>
         )}
       </ScrollView>
     </SafeAreaView>

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import {SafeAreaView, ScrollView, Text, Alert} from 'react-native';
+import {SafeAreaView, Text, Alert, FlatList, View} from 'react-native';
 
 import {globalStyles} from '@src/globalStyles';
 import {styles} from './styles';
@@ -20,9 +20,14 @@ interface ListUsersData {
   users: {nodes: User[]};
 }
 
+interface PageData {
+  offset: number;
+  limit: number;
+}
+
 const GET_USERS = gql`
-  query ListUsers {
-    users {
+  query ListUsers($offset: Int, $limit: Int) {
+    users(data: {offset: $offset, limit: $limit}) {
       nodes {
         id
         name
@@ -32,12 +37,24 @@ const GET_USERS = gql`
   }
 `;
 
-export const Home = () => {
-  const {data, loading, error, refetch} = useQuery<ListUsersData>(GET_USERS, {
-    notifyOnNetworkStatusChange: true,
-  });
+const PAGE_SIZE = 10;
 
-  const showAlert = () =>
+export const Home = () => {
+  const [currentPage, setCurrentPage] = React.useState(0);
+  const [users, setUsers] = React.useState<User[]>([]);
+  const {data, loading, error, refetch} = useQuery<ListUsersData, PageData>(
+    GET_USERS,
+    {
+      variables: {
+        offset: currentPage * PAGE_SIZE,
+        limit: PAGE_SIZE,
+      },
+      onCompleted: handleQueryCompleted,
+      notifyOnNetworkStatusChange: true,
+    },
+  );
+
+  function showAlert() {
     Alert.alert(
       'Erro',
       'Houve um erro na requisição para listagem dos usuários',
@@ -51,27 +68,37 @@ export const Home = () => {
         },
       ],
     );
+  }
+
+  function handleEndReached() {
+    setCurrentPage(currentPage + 1);
+  }
+
+  function handleQueryCompleted() {
+    setUsers(oldUsers =>
+      data ? [...oldUsers, ...data.users.nodes] : oldUsers,
+    );
+  }
 
   if (error) {
     showAlert();
   }
 
-  if (loading) {
-    return <LoadingIndicator />;
-  }
-
   return (
     <SafeAreaView style={globalStyles.container}>
       <Text style={globalStyles.title}>Lista de usuários</Text>
-      <ScrollView style={styles.userListContainer}>
-        {data && data.users.nodes.length > 0 ? (
-          data.users.nodes.map(user => (
-            <UserItem name={user.name} email={user.email} key={user.id} />
-          ))
-        ) : (
-          <Text>Sem usuários para listar</Text>
-        )}
-      </ScrollView>
+      <View style={styles.userListContainer}>
+        <FlatList
+          data={users || []}
+          renderItem={({item}) => (
+            <UserItem name={item.name} email={item.email} />
+          )}
+          keyExtractor={item => String(item.id)}
+          ListEmptyComponent={<Text>Sem usuários para listar</Text>}
+          onEndReached={handleEndReached}
+        />
+        {loading ? <LoadingIndicator /> : null}
+      </View>
     </SafeAreaView>
   );
 };

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -1,58 +1,42 @@
 import * as React from 'react';
 
-import {SafeAreaView, ScrollView, Text} from 'react-native';
+import {ActivityIndicator, SafeAreaView, ScrollView, Text} from 'react-native';
 
 import {globalStyles} from '@src/globalStyles';
-import {UserItem} from './components/UserItem';
 import {styles} from './styles';
 
-const dummyUsers = [
-  {id: 1, name: 'Davi Felix', email: 'davi.felix@taqtile.com.br'},
-  {id: 2, name: 'Alan Raso', email: 'alan.raso@taqtile.com.br'},
-  {id: 3, name: 'Erick Sousa', email: 'erick.sousa@taqtile.com.br'},
-  {id: 4, name: 'Bruno Brandão', email: 'bruno.brandrao@taqtile.com.br'},
-  {id: 5, name: 'Daniel Ueno', email: 'daniel.ueno@taqtile.com.br'},
-  {id: 6, name: 'Eduardo Grimori', email: 'eduardo.grimori@taqtile.com.br'},
-  {id: 7, name: 'John Smith', email: 'john.smith@taqtile.com.br'},
-  {id: 8, name: 'Emily Johnson', email: 'emily.johnson@taqtile.com.br'},
-  {id: 9, name: 'Michael Williams', email: 'michael.williams@taqtile.com.br'},
-  {id: 10, name: 'Emma Brown', email: 'emma.brown@taqtile.com.br'},
-  {id: 11, name: 'Daniel Jones', email: 'daniel.jones@taqtile.com.br'},
-  {id: 12, name: 'Sophia Garcia', email: 'sophia.garcia@taqtile.com.br'},
-  {id: 13, name: 'Matthew Davis', email: 'matthew.davis@taqtile.com.br'},
-  {id: 14, name: 'Olivia Rodriguez', email: 'olivia.rodriguez@taqtile.com.br'},
-  {
-    id: 15,
-    name: 'Alexander Martinez',
-    email: 'alexander.martinez@taqtile.com.br',
-  },
-  {
-    id: 16,
-    name: 'Isabella Hernandez',
-    email: 'isabella.hernandez@taqtile.com.br',
-  },
-  {id: 17, name: 'Ethan Lopez', email: 'ethan.lopez@taqtile.com.br'},
-  {id: 18, name: 'Mia Gonzalez', email: 'mia.gonzalez@taqtile.com.br'},
-  {id: 19, name: 'David Wilson', email: 'david.wilson@taqtile.com.br'},
-  {id: 20, name: 'Ava Perez', email: 'ava.perez@taqtile.com.br'},
-  {id: 21, name: 'James Moore', email: 'james.moore@taqtile.com.br'},
-  {id: 22, name: 'Charlotte Taylor', email: 'charlotte.taylor@taqtile.com.br'},
-  {
-    id: 23,
-    name: 'Benjamin Anderson',
-    email: 'benjamin.anderson@taqtile.com.br',
-  },
-  {id: 24, name: 'Amelia Thomas', email: 'amelia.thomas@taqtile.com.br'},
-  {id: 25, name: 'Daniel Jackson', email: 'daniel.jackson@taqtile.com.br'},
-  {id: 26, name: 'Elizabeth White', email: 'elizabeth.white@taqtile.com.br'},
-];
+import {UserItem} from './components/UserItem';
+
+import {gql, useQuery} from '@apollo/client';
+
+const GET_USERS = gql`
+  query ListUsers {
+    users {
+      nodes {
+        id
+        name
+        email
+      }
+    }
+  }
+`;
 
 export const Home = () => {
+  const {data, loading, error} = useQuery(GET_USERS);
+
+  if (error) {
+    console.log(error);
+  }
+
+  if (loading) {
+    return <ActivityIndicator />;
+  }
+
   return (
     <SafeAreaView style={globalStyles.container}>
       <Text style={globalStyles.title}>Lista de usuários</Text>
       <ScrollView style={styles.userListContainer}>
-        {dummyUsers.map(user => (
+        {data.users.nodes.map(user => (
           <UserItem name={user.name} email={user.email} key={user.id} />
         ))}
       </ScrollView>

--- a/src/screens/home/styles.ts
+++ b/src/screens/home/styles.ts
@@ -3,6 +3,7 @@ import {StyleSheet} from 'react-native';
 export const styles = StyleSheet.create({
   userListContainer: {
     marginTop: 16,
-    marginBottom: 32,
+    marginBottom: 8,
+    flex: 1,
   },
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,24 @@
-import {ApolloClient, InMemoryCache} from '@apollo/client';
+import {ApolloClient, createHttpLink, InMemoryCache} from '@apollo/client';
+import {setContext} from '@apollo/client/link/context';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const httpLink = createHttpLink({
+  uri: 'https://template-onboarding-node-sjz6wnaoia-uc.a.run.app/graphql',
+});
+
+const authLink = setContext(async (_, {headers}) => {
+  // get the authentication token from local storage if it exists
+  const token = await AsyncStorage.getItem('ONBOARDING-APP:accessToken');
+  // return the headers to the context so httpLink can read them
+  return {
+    headers: {
+      ...headers,
+      authorization: token || '',
+    },
+  };
+});
 
 export const client = new ApolloClient({
-  uri: 'https://template-onboarding-node-sjz6wnaoia-uc.a.run.app/graphql',
+  link: authLink.concat(httpLink),
   cache: new InMemoryCache(),
 });


### PR DESCRIPTION
Foi adicionada a funcionalidade de scroll infinito para paginar os resultados da listagem de usuários. O resultado pode ser visto no vídeo abaixo:

Nessa implementação, o argumentos dos `hooks` foram manipulados diretamente e nem todos os resultados são guardados em cache.


https://github.com/indigotech/onboard-davi-felix/assets/62623519/f4767e89-0756-4768-a901-627a4430ecaa

