### PR TITLE
Add read function to recover cache with pagination

### DIFF
--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -94,6 +94,7 @@ export const Home = ({navigation}: HomeScreenProps) => {
       fetchMore({
         variables: {
           offset: users.length,
+          limit: PAGE_SIZE,
         },
       }).then(result => {
         setLimit(users.length + result.data.users.nodes.length);

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -58,12 +58,13 @@ type HomeScreenProps = NativeStackScreenProps<RootStackParamsList, 'Home'>;
 const PAGE_SIZE = 10;
 
 export const Home = ({navigation}: HomeScreenProps) => {
+  const [limit, setLimit] = React.useState(PAGE_SIZE);
   const {data, loading, refetch, fetchMore} = useQuery<ListUsersData, PageData>(
     GET_USERS,
     {
       variables: {
         offset: 0,
-        limit: PAGE_SIZE,
+        limit,
       },
       onError: showAlert,
       notifyOnNetworkStatusChange: true,
@@ -93,6 +94,8 @@ export const Home = ({navigation}: HomeScreenProps) => {
       variables: {
         offset: users.length,
       },
+    }).then(result => {
+      setLimit(users.length + result.data.users.nodes.length);
     });
   }
 

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -90,13 +90,15 @@ export const Home = ({navigation}: HomeScreenProps) => {
   }
 
   function handleEndReached() {
-    fetchMore({
-      variables: {
-        offset: users.length,
-      },
-    }).then(result => {
-      setLimit(users.length + result.data.users.nodes.length);
-    });
+    if (data?.users.pageInfo.hasNextPage) {
+      fetchMore({
+        variables: {
+          offset: users.length,
+        },
+      }).then(result => {
+        setLimit(users.length + result.data.users.nodes.length);
+      });
+    }
   }
 
   function handlePressAddButton() {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -38,6 +38,17 @@ export const client = new ApolloClient({
                 pageInfo: incoming.pageInfo,
               };
             },
+            read(existing, {args}) {
+              const {offset, limit} = args?.data;
+              if (existing) {
+                const users = existing.nodes;
+                return {
+                  nodes: users.slice(offset, offset + limit),
+                  pageInfo: existing.pageInfo,
+                };
+              }
+              return existing;
+            },
           },
         },
       },


### PR DESCRIPTION
Implementando paginação com a [Apollo Client API](https://www.apollographql.com/docs/react/pagination/offset-based) usando uma função de `read` para recuperar o cache também com paginação.

Agora a paginação ocorre mesmo ao sair e entrar da tela, o que antes não era o caso usando a lógica do `fetchMore`:


https://github.com/indigotech/onboard-davi-felix/assets/62623519/d56f4034-ae2e-4326-a9f2-c546a320693e

