### PR TITLE
Simplify user listing without Apollo Cache

### DIFF
--- a/src/graphql/listUsers.ts
+++ b/src/graphql/listUsers.ts
@@ -1,6 +1,6 @@
 import {gql} from '@apollo/client';
 
-interface User {
+export interface User {
   id: number;
   name: string;
   email: string;

--- a/src/screens/Routes.tsx
+++ b/src/screens/Routes.tsx
@@ -13,7 +13,9 @@ import {UserDetail} from './user-detail/UserDetail';
 
 export type RootStackParamsList = {
   Login: undefined;
-  Home: undefined;
+  Home?: {
+    updateUsers: boolean;
+  };
   AddUser: undefined;
   UserDetail: {
     userId: number;
@@ -32,7 +34,11 @@ export const Routes = () => {
         initialRouteName="Login"
         screenOptions={{headerShown: false}}>
         <Stack.Screen name="Login" component={Login} />
-        <Stack.Screen name="Home" component={Home} />
+        <Stack.Screen
+          name="Home"
+          component={Home}
+          initialParams={{updateUsers: false}}
+        />
         <Stack.Screen name="AddUser" component={AddUser} />
         <Stack.Screen name="UserDetail" component={UserDetail} />
       </Stack.Navigator>

--- a/src/screens/Routes.tsx
+++ b/src/screens/Routes.tsx
@@ -37,7 +37,7 @@ export const Routes = () => {
         <Stack.Screen
           name="Home"
           component={Home}
-          initialParams={{updateUsers: false}}
+          initialParams={{updateUsers: true}}
         />
         <Stack.Screen name="AddUser" component={AddUser} />
         <Stack.Screen name="UserDetail" component={UserDetail} />

--- a/src/screens/add-user/AddUser.tsx
+++ b/src/screens/add-user/AddUser.tsx
@@ -49,7 +49,7 @@ export const AddUser = ({navigation}: ScreenProps<'AddUser'>) => {
     React.useState<Record<ErrorObjectIndex, string[]>>(noErrors);
 
   function handleCreateNewUserComplete() {
-    navigation.navigate('Home');
+    navigation.navigate('Home', {updateUsers: true});
   }
 
   function handleCreateNewUserError(error: ApolloError) {

--- a/src/screens/add-user/AddUser.tsx
+++ b/src/screens/add-user/AddUser.tsx
@@ -36,7 +36,6 @@ export const AddUser = ({navigation}: ScreenProps<'AddUser'>) => {
   >(ADD_USER_MUTATION, {
     onCompleted: handleCreateNewUserComplete,
     onError: handleCreateNewUserError,
-    refetchQueries: ['ListUsers'],
   });
 
   const [name, setName] = React.useState('');

--- a/src/screens/add-user/AddUser.tsx
+++ b/src/screens/add-user/AddUser.tsx
@@ -49,7 +49,7 @@ export const AddUser = ({navigation}: ScreenProps<'AddUser'>) => {
     React.useState<Record<ErrorObjectIndex, string[]>>(noErrors);
 
   function handleCreateNewUserComplete() {
-    navigation.navigate('Home', {updateUsers: true});
+    navigation.navigate('Home');
   }
 
   function handleCreateNewUserError(error: ApolloError) {

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -51,7 +51,7 @@ export const Home = ({navigation, route}: ScreenProps<'Home'>) => {
       if (updateUsers) {
         handleRefetchQuery();
       }
-      // Ensures that users will no update on gesture goBack
+      // Ensures that users will not update on go back gesture
       navigation.setParams({updateUsers: false});
     }, [handleRefetchQuery, updateUsers, navigation]),
   );

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -22,7 +22,8 @@ import {useFocusEffect} from '@react-navigation/native';
 
 const PAGE_SIZE = 10;
 
-export const Home = ({navigation}: ScreenProps<'Home'>) => {
+export const Home = ({navigation, route}: ScreenProps<'Home'>) => {
+  const updateUsers = route.params?.updateUsers;
   const [currentPage, setCurrentPage] = React.useState(0);
   const [users, setUsers] = React.useState<User[]>([]);
   const [refreshing, setRefresing] = React.useState(false);
@@ -40,8 +41,19 @@ export const Home = ({navigation}: ScreenProps<'Home'>) => {
     },
   );
 
+  const handleRefetchQuery = React.useCallback(() => {
+    setUsers([]);
+    setCurrentPage(0);
+  }, [setUsers, setCurrentPage]);
+
   useFocusEffect(
-    React.useCallback(handleRefetchQuery, [setUsers, setCurrentPage]),
+    React.useCallback(() => {
+      if (updateUsers) {
+        handleRefetchQuery();
+      }
+      // Ensures that users will no update on gesture goBack
+      navigation.setParams({updateUsers: false});
+    }, [handleRefetchQuery, updateUsers, navigation]),
   );
 
   function showAlert() {
@@ -58,11 +70,6 @@ export const Home = ({navigation}: ScreenProps<'Home'>) => {
         },
       ],
     );
-  }
-
-  function handleRefetchQuery() {
-    setUsers([]);
-    setCurrentPage(0);
   }
 
   function handleQueryCompleted(reponseData: ListUsersData) {

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -12,26 +12,37 @@ import {ScreenProps} from '../Routes';
 
 import {useQuery} from '@apollo/client';
 
-import {ListUsersData, PageData, GET_USERS_QUERY} from '@src/graphql/listUsers';
+import {
+  ListUsersData,
+  PageData,
+  GET_USERS_QUERY,
+  User,
+} from '@src/graphql/listUsers';
+import {useFocusEffect} from '@react-navigation/native';
 
 const PAGE_SIZE = 10;
 
 export const Home = ({navigation}: ScreenProps<'Home'>) => {
-  const [limit, setLimit] = React.useState(PAGE_SIZE);
+  const [currentPage, setCurrentPage] = React.useState(0);
+  const [users, setUsers] = React.useState<User[]>([]);
   const [refreshing, setRefresing] = React.useState(false);
-  const {data, loading, refetch, fetchMore} = useQuery<ListUsersData, PageData>(
+  const {data, loading, refetch} = useQuery<ListUsersData, PageData>(
     GET_USERS_QUERY,
     {
       variables: {
-        offset: 0,
-        limit,
+        offset: currentPage * PAGE_SIZE,
+        limit: PAGE_SIZE,
       },
       onError: showAlert,
+      onCompleted: handleQueryCompleted,
       notifyOnNetworkStatusChange: true,
+      fetchPolicy: 'no-cache',
     },
   );
 
-  const users = data?.users.nodes ?? [];
+  useFocusEffect(
+    React.useCallback(handleRefetchQuery, [setUsers, setCurrentPage]),
+  );
 
   function showAlert() {
     Alert.alert(
@@ -49,16 +60,21 @@ export const Home = ({navigation}: ScreenProps<'Home'>) => {
     );
   }
 
+  function handleRefetchQuery() {
+    setUsers([]);
+    setCurrentPage(0);
+  }
+
+  function handleQueryCompleted(reponseData: ListUsersData) {
+    if (reponseData) {
+      const newUsers = reponseData.users.nodes;
+      setUsers(oldUsers => [...oldUsers, ...newUsers]);
+    }
+  }
+
   function handleEndReached() {
     if (data?.users.pageInfo.hasNextPage) {
-      fetchMore({
-        variables: {
-          offset: users.length,
-          limit: PAGE_SIZE,
-        },
-      }).then(result => {
-        setLimit(users.length + result.data.users.nodes.length);
-      });
+      setCurrentPage(currPage => currPage + 1);
     }
   }
 
@@ -74,7 +90,7 @@ export const Home = ({navigation}: ScreenProps<'Home'>) => {
 
   async function handleRefresh() {
     setRefresing(true);
-    await refetch({offset: 0, limit: PAGE_SIZE});
+    handleRefetchQuery();
     setRefresing(false);
   }
 

--- a/src/screens/login/Login.tsx
+++ b/src/screens/login/Login.tsx
@@ -34,7 +34,7 @@ export const Login = ({navigation}: ScreenProps<'Login'>) => {
     const token = data?.login.token ?? '';
     try {
       await AsyncStorage.setItem('ONBOARDING-APP:accessToken', token);
-      navigation.navigate('Home');
+      navigation.navigate('Home', {updateUsers: true});
     } catch {
       console.log('Error saving token');
     }

--- a/src/screens/login/Login.tsx
+++ b/src/screens/login/Login.tsx
@@ -34,7 +34,7 @@ export const Login = ({navigation}: ScreenProps<'Login'>) => {
     const token = data?.login.token ?? '';
     try {
       await AsyncStorage.setItem('ONBOARDING-APP:accessToken', token);
-      navigation.navigate('Home', {updateUsers: true});
+      navigation.navigate('Home');
     } catch {
       console.log('Error saving token');
     }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,38 +20,5 @@ const authLink = setContext(async (_, {headers}) => {
 
 export const client = new ApolloClient({
   link: authLink.concat(httpLink),
-  cache: new InMemoryCache({
-    typePolicies: {
-      Query: {
-        fields: {
-          users: {
-            keyArgs: false,
-            merge(existing, incoming, {args}) {
-              const {offset} = args?.data;
-              const merged = existing ? existing?.nodes.slice(0) : [];
-              for (let i = 0; i < incoming.nodes.length; ++i) {
-                merged[offset + i] = incoming.nodes[i];
-              }
-              return {
-                __typename: incoming.__typename,
-                nodes: merged,
-                pageInfo: incoming.pageInfo,
-              };
-            },
-            read(existing, {args}) {
-              const {offset, limit} = args?.data;
-              if (existing) {
-                const users = existing.nodes;
-                return {
-                  nodes: users.slice(offset, offset + limit),
-                  pageInfo: existing.pageInfo,
-                };
-              }
-              return existing;
-            },
-          },
-        },
-      },
-    },
-  }),
+  cache: new InMemoryCache(),
 });


### PR DESCRIPTION
Ajustando a funcionalidade de paginação para algo mais simples, sem a necessidade do cache do Apollo. Foi usado um parâmetro de navegação para garantir que os usuários passem por update apenas quando navegado a partir de determinadas páginas. Para viabilizar esse fluxo, foi usado o hook [useFocusEffect](https://reactnavigation.org/docs/use-focus-effect/), que define uma função executada toda vez que o usuário entra na tela.